### PR TITLE
add illumos support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ Get os native machine id without root permission.
 [target.'cfg(windows)'.dependencies]
 winreg = "0.11"
 
+[target.'cfg(target_os = "illumos")'.dependencies]
+libc = "0.2.155"
+
 [build-dependencies]
 cc = "1.0"
 bindgen = "0.59"

--- a/README.md
+++ b/README.md
@@ -59,15 +59,22 @@ Windows:
 (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography).MachineGuid
 ```
 
+illumos:
+
+```Bash
+gethostid(3C)
+```
+
 ### Supported Platform
 
 I have tested in following platform:
 
 - Debian 8
 - OS X 10.6
-- FeeBSD 10.4
+- FreeBSD 10.4
 - Fedora 28
 - Windows 10
+- OmniOS r151050
 
 ### License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,15 +50,22 @@
 //! (Get-ItemProperty -Path Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Cryptography).MachineGuid
 //! ```
 //!
+//! illumos:
+//!
+//! ```Bash
+//! gethostid(3C)
+//! ```
+//!
 //! ## Supported Platform
 //!
 //! I have tested in following platform:
 //!
 //! - Debian 8
 //! - OS X 10.6
-//! - FeeBSD 10.4
+//! - FreeBSD 10.4
 //! - Fedora 28
 //! - Windows 10
+//! - OmniOS r151050
 //!
 
 use std::error::Error;
@@ -177,6 +184,16 @@ pub mod machine_id {
         let id: String = crypto.get_value("MachineGuid")?;
 
         Ok(id.trim().to_string())
+    }
+}
+
+#[cfg(target_os = "illumos")]
+pub mod machine_id {
+    use std::error::Error;
+
+    /// Return machine id
+    pub fn get_machine_id() -> Result<String, Box<dyn Error>> {
+        Ok(format!("{:x}", unsafe { libc::gethostid() }))
     }
 }
 


### PR DESCRIPTION
It looks like `rustdesk` is using its own fork of `machine-uid`. Please consider adding illumos support like the upstream repo did: https://github.com/Hanaasagi/machine-uid/pull/11